### PR TITLE
Fixing bug and improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ try(FileWriter fw = new FileWriter(temp))
 // Create an Apache Commons VFS manager option and add 2 providers. Local file and Azure.
 // All done programmatically
 DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
 currMan.addProvider("file", new DefaultLocalFileProvider());
 currMan.init(); 
 
@@ -42,7 +42,7 @@ DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator(opts, auth);
 // Create a URL for creating this remote file
 currFileNameStr = "test01.tmp";
 String currUriStr = String.format("%s://%s/%s/%s", 
-                   AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                   AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
 
 // Resolve the imaginary file remotely.  So we have a file object
 FileObject currFile = currMan.resolveFile(currUriStr, opts);

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# This fork is deprecated
+
+The deltas on this fork have been moved to https://github.com/dalet-oss/vfs-azure/, and ongoing development will
+continue there.
+
+
 # vfs-azure
 Azure provider for Apache Commons VFS - http://commons.apache.org/proper/commons-vfs/
 

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3</version>
+    <version>1.3.1</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>6.0.0</version>
+            <version>6.1.0</version>
         </dependency>
 
         <dependency>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>
@@ -156,7 +156,14 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.10</version>
         </dependency>
-        
+
+        <!-- https://mvnrepository.com/artifact/org.apache.tika/tika-core -->
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.16</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.7</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,8 +4,8 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.1</version>
- 
+    <version>1.3</version>
+    
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>
     <url>https://github.com/kervinpierre/vfs-azure</url>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>6.0.0.1</version>
+            <version>6.0.0</version>
         </dependency>
 
         <dependency>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,8 +4,8 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3</version>
-    
+    <version>1.3.1</version>
+ 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>
     <url>https://github.com/kervinpierre/vfs-azure</url>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>4.0.0</version>
+            <version>6.0.0.1</version>
         </dependency>
 
         <dependency>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -134,10 +134,17 @@
         </dependency>
         
         <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>2.1.0</version>
+            <version>4.0.0</version>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -4,7 +4,7 @@
     
     <groupId>com.sludev.commons</groupId>
     <artifactId>vfs-azure</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Azure Blob Storage Provider for the Apache Commons VFS library.</description>

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzConstants.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzConstants.java
@@ -27,10 +27,10 @@ public class AzConstants
     /**
      * Azure Blob Storage API
      */
-    public static final String AZSBSCHEME = "azsb";
+    public static final String AZBSSCHEME = "azbs";
     
     /**
      * Azure File Storage API
      */
-    public static final String AZSFSCHEME = "azsf";
+    public static final String AZFSSCHEME = "azfs";
 }

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -538,6 +538,9 @@ public class AzFileObject extends AbstractFileObject {
                     destFile.delete(Selectors.SELECT_ALL);
                 }
 
+                // We need to reques the CloudBlockBlock for the that we want to upload, as we were always using the
+                // CloudBlockBlob of the root directory when we were trying to copy directories, hence it was always overwriting
+                // the root directory on azure storage.
                 CloudBlockBlob fileCurrBlob = getFileCurrBlob(destFile);
 
                 try {
@@ -597,6 +600,11 @@ public class AzFileObject extends AbstractFileObject {
     }
 
 
+    /**
+     * Returns the file CloudBlockBloc of the give file.
+     * If the file is not the type of AzFileObject or does not have its own CloudBlockBloc it is going to return the
+     * CloudBlockBlob of the current file.
+     */
     private CloudBlockBlob getFileCurrBlob(FileObject destFile) {
 
         CloudBlockBlob cloudBlockBlob = currBlob;

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -637,7 +637,7 @@ public class AzFileObject extends AbstractFileObject {
 
 
     /**
-     * Compares account and container name to check possibilities of copying file using server to server copy option
+     * Compares credential to check possibilities of copying file at server side.
      *
      * @param sourceFileObject
      * @param destinationFileObject
@@ -646,11 +646,6 @@ public class AzFileObject extends AbstractFileObject {
     private boolean canCopyServerSide(FileObject sourceFileObject, FileObject destinationFileObject) {
 
         if (!(sourceFileObject instanceof AzFileObject) || !(destinationFileObject instanceof AzFileObject)) {
-            return false;
-        }
-
-        // No point to copy server side if their file system is different
-        if (!(sourceFileObject.getFileSystem() == destinationFileObject.getFileSystem())) {
             return false;
         }
 
@@ -663,7 +658,7 @@ public class AzFileObject extends AbstractFileObject {
 
         return sourceAccountName != null
                 && destinationAccountName != null
-                && sourceAccountName.equalsIgnoreCase(destinationAccountName);
+                && sourceAccountName.equals(destinationAccountName);
     }
 
 
@@ -679,6 +674,7 @@ public class AzFileObject extends AbstractFileObject {
 
         return azFileSystem.getClient() != null ? azFileSystem.getClient().getCredentials().getAccountName() : null;
     }
+
 
 
     /**

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -73,11 +73,11 @@ public class AzFileObject extends AbstractFileObject {
     private static final int MEGABYTES_TO_BYTES_MULTIPLIER = (int) Math.pow(2.0, 20.0);
 
     //azure concurrent upload request count
-    private static int AZURE_CONCURRENT_REQUEST_CCOUNT = 5;
+    private static int AZURE_CONCURRENT_REQUEST_CCOUNT = 3;
 
     private static Boolean ENABLE_AZURE_STORAGE_LOG = false;
 
-    static Integer UPLOAD_BLOCK_SIZE = 2; //in MB's
+    static Integer UPLOAD_BLOCK_SIZE = 3; //in MB's
 
     private static Tika tika = new Tika();
 

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -425,4 +425,17 @@ public class AzFileObject extends AbstractFileObject
         
         return res;
     }
+
+    /**
+     * We need to override this method, because the parent one throws an exception.
+     *
+     * @param modtime the last modified time to set.
+     * @return true if setting the last modified time was successful.
+     * @throws Exception
+     */
+    @Override
+    protected boolean doSetLastModifiedTime(long modtime) throws Exception
+    {
+        return true;
+    }
 }

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -18,7 +18,6 @@ package com.sludev.commons.vfs2.provider.azure;
 
 import com.microsoft.azure.storage.OperationContext;
 import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.BlobContainerProperties;
 import com.microsoft.azure.storage.blob.BlobInputStream;
 import com.microsoft.azure.storage.blob.BlobProperties;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
@@ -66,7 +65,6 @@ public class AzFileObject extends AbstractFileObject {
     private final AzFileSystem fileSystem;
     private CloudBlobContainer currContainer;
     private CloudBlockBlob currBlob;
-    private BlobContainerProperties currContainerProperties;
     private BlobProperties currBlobProperties;
 
     private static final int MEGABYTES_TO_BYTES_MULTIPLIER = (int) Math.pow(2.0, 20.0);
@@ -110,7 +108,6 @@ public class AzFileObject extends AbstractFileObject {
         currContainer = null;
         currBlob = null;
         currBlobProperties = null;
-        currContainerProperties = null;
     }
 
 
@@ -443,7 +440,6 @@ public class AzFileObject extends AbstractFileObject {
         currBlob = null;
         currContainer = null;
         currBlobProperties = null;
-        currContainerProperties = null;
     }
 
 
@@ -538,7 +534,7 @@ public class AzFileObject extends AbstractFileObject {
                     destFile.delete(Selectors.SELECT_ALL);
                 }
 
-                // We need to reques the CloudBlockBlock for the that we want to upload, as we were always using the
+                // We need to requires the CloudBlockBlob for the that we want to upload, as we were always using the
                 // CloudBlockBlob of the root directory when we were trying to copy directories, hence it was always overwriting
                 // the root directory on azure storage.
                 CloudBlockBlob fileCurrBlob = getFileCurrBlob(destFile);
@@ -601,8 +597,8 @@ public class AzFileObject extends AbstractFileObject {
 
 
     /**
-     * Returns the file CloudBlockBloc of the give file.
-     * If the file is not the type of AzFileObject or does not have its own CloudBlockBloc it is going to return the
+     * Returns the file CloudBlockBlob of the give file.
+     * If the file is not the type of AzFileObject or does not have its own CloudBlockBlob it is going to return the
      * CloudBlockBlob of the current file.
      */
     private CloudBlockBlob getFileCurrBlob(FileObject destFile) {

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -72,9 +72,6 @@ public class AzFileObject extends AbstractFileObject {
 
     private static final int MEGABYTES_TO_BYTES_MULTIPLIER = (int) Math.pow(2.0, 20.0);
 
-    //azure concurrent upload request count
-    private static int AZURE_CONCURRENT_REQUEST_CCOUNT = 3;
-
     private static Boolean ENABLE_AZURE_STORAGE_LOG = false;
 
     static Integer UPLOAD_BLOCK_SIZE = 3; //in MB's
@@ -86,16 +83,12 @@ public class AzFileObject extends AbstractFileObject {
         String uploadBlockSizeProperty = System.getProperty("azure.upload.block.size");
         UPLOAD_BLOCK_SIZE = (int) NumberUtils.toLong(uploadBlockSizeProperty, UPLOAD_BLOCK_SIZE) * MEGABYTES_TO_BYTES_MULTIPLIER;
 
-        String azureConcurrentReqCount = System.getProperty("azure.concurrent.request.count");
-        AZURE_CONCURRENT_REQUEST_CCOUNT = NumberUtils.toInt(azureConcurrentReqCount, AZURE_CONCURRENT_REQUEST_CCOUNT);
-
-        String enableAzureLogging = System.getProperty("azure.enable.logging");
+         String enableAzureLogging = System.getProperty("azure.enable.logging");
         if (StringUtils.isNotEmpty(enableAzureLogging)) {
             ENABLE_AZURE_STORAGE_LOG = BooleanUtils.toBoolean(enableAzureLogging);
         }
 
-        log.info("Azure upload block size : {} Bytes, concurrent request count: {}", UPLOAD_BLOCK_SIZE,
-                AZURE_CONCURRENT_REQUEST_CCOUNT);
+        log.info("Azure upload block size : {} Bytes, concurrent request count: {}", UPLOAD_BLOCK_SIZE);
     }
 
     /**
@@ -569,10 +562,7 @@ public class AzFileObject extends AbstractFileObject {
                             OperationContext opContext = new OperationContext();
                             opContext.setLoggingEnabled(ENABLE_AZURE_STORAGE_LOG);
 
-                            BlobRequestOptions modifiedOptions = new BlobRequestOptions();
-                            modifiedOptions.setConcurrentRequestCount(AZURE_CONCURRENT_REQUEST_CCOUNT);
-
-                            currBlob.upload(sourceStream, length, null, modifiedOptions, opContext);
+                            currBlob.upload(sourceStream, length, null, null, opContext);
 
                         }
                         finally {

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -661,17 +661,9 @@ public class AzFileObject extends AbstractFileObject {
 
         String destinationAccountName = getAccountName(azDestinationFileObject);
 
-        if (sourceAccountName != null
+        return sourceAccountName != null
                 && destinationAccountName != null
-                && sourceAccountName.equalsIgnoreCase(destinationAccountName)) {
-
-            String srcContainerName = azSourceFileObject.getContainerAndPath().getKey();
-            String destContainerName = azDestinationFileObject.getContainerAndPath().getKey();
-
-            return srcContainerName.equalsIgnoreCase(destContainerName);
-        }
-
-        return false;
+                && sourceAccountName.equalsIgnoreCase(destinationAccountName);
     }
 
 

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -32,6 +32,8 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.vfs2.FileNotFolderException;
+import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.provider.AbstractFileName;
@@ -437,5 +439,29 @@ public class AzFileObject extends AbstractFileObject
     protected boolean doSetLastModifiedTime(long modtime) throws Exception
     {
         return true;
+    }
+
+    /**
+     * Returns the file's list of children.
+     *
+     * @return The list of children
+     * @throws FileSystemException If there was a problem listing children
+     * @see AbstractFileObject#getChildren()
+     */
+    @Override
+    public FileObject[] getChildren() throws FileSystemException {
+
+        try {
+            // Folders which are copied from other folders, have type = IMAGINARY. We can not throw exception based on folder
+            // type only and so we have check here for content.
+            if (getType().hasContent()) {
+                throw new FileNotFolderException(getName());
+            }
+        }
+        catch (Exception ex) {
+            throw new FileNotFolderException(getName(), ex);
+        }
+
+        return super.getChildren();
     }
 }

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -553,18 +553,16 @@ public class AzFileObject extends AbstractFileObject {
                                 fileCurrBlob.setStreamWriteSizeInBytes(UPLOAD_BLOCK_SIZE);
                             }
 
-                            if (currBlobProperties == null) {
-                                currBlobProperties = fileCurrBlob.getProperties();
-                            }
+                            BlobProperties fileCurrBlobProperties = fileCurrBlob.getProperties();
 
-                            if (currBlobProperties != null) {
+                            if (fileCurrBlobProperties != null) {
                                 String fileName = srcFile.getName().getBaseName();
                                 String contentType = tika.detect(fileName);
 
                                 log.debug("Content type is {} for {} file", contentType, fileName);
 
                                 if (contentType != null) {
-                                    currBlobProperties.setContentType(contentType);
+                                    fileCurrBlobProperties.setContentType(contentType);
                                 }
                             }
                             else {

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileObject.java
@@ -554,7 +554,7 @@ public class AzFileObject extends AbstractFileObject {
                             }
 
                             if (currBlobProperties == null) {
-                                currBlobProperties = currBlob.getProperties();
+                                currBlobProperties = fileCurrBlob.getProperties();
                             }
 
                             if (currBlobProperties != null) {

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileProvider.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileProvider.java
@@ -168,7 +168,7 @@ public class AzFileProvider
     @Override
     protected FileSystem doCreateFileSystem(FileName rootName, FileSystemOptions fileSystemOptions) throws FileSystemException
     {
-        AzFileSystem fileSystem = null;
+        AzFileSystem fileSystem;
         GenericFileName genRootName = (GenericFileName)rootName;
         
         StorageCredentials storageCreds;
@@ -190,7 +190,7 @@ public class AzFileProvider
                     UserAuthenticationData.PASSWORD, UserAuthenticatorUtils.toChar(genRootName.getPassword())));
         
             storageCreds = new StorageCredentialsAccountAndKey(currAcct, currKey);           
-            storageAccount = new CloudStorageAccount(storageCreds);
+            storageAccount = new CloudStorageAccount(storageCreds, true);
             
             client = storageAccount.createCloudBlobClient();
             

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileProvider.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileProvider.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * // Create an Apache Commons VFS manager option and add 2 providers. Local file and Azure.
  * // All done programmatically
  * DefaultFileSystemManager currMan = new DefaultFileSystemManager();
- * currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+ * currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
  * currMan.addProvider("file", new DefaultLocalFileProvider());
  * currMan.init(); 
 
@@ -77,7 +77,7 @@ import org.slf4j.LoggerFactory;
  * // Create a URL for creating this remote file
  * currFileNameStr = "test01.tmp";
  * String currUriStr = String.format("%s://%s/%s/%s", 
- *                    AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+ *                    AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
  * 
  * // Resolve the imaginary file remotely.  So we have a file object
  * FileObject currFile = currMan.resolveFile(currUriStr, opts);

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileProvider.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileProvider.java
@@ -152,7 +152,7 @@ public class AzFileProvider
      * 
      * @return 
      */
-    public FileSystemOptions getDefaultFileSystemOptions()
+    public static FileSystemOptions getDefaultFileSystemOptions()
     {
         return DEFAULT_OPTIONS;
     }
@@ -175,20 +175,9 @@ public class AzFileProvider
         CloudStorageAccount storageAccount;
         CloudBlobClient client;
         
-        FileSystemOptions currFSO;
-        UserAuthenticator ua;
-        
-        if( fileSystemOptions == null )
-        {
-            currFSO = getDefaultFileSystemOptions();
-            ua = AzFileSystemConfigBuilder.getInstance().getUserAuthenticator(currFSO);  
-        }
-        else
-        {
-            currFSO = fileSystemOptions;
-            ua = DefaultFileSystemConfigBuilder.getInstance().getUserAuthenticator(currFSO);
-        }
-        
+        FileSystemOptions currFSO = (fileSystemOptions != null) ? fileSystemOptions : getDefaultFileSystemOptions();
+        UserAuthenticator ua = DefaultFileSystemConfigBuilder.getInstance().getUserAuthenticator(currFSO);
+
         UserAuthenticationData authData = null;
         try
         {

--- a/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileSystem.java
+++ b/vfs-azure/src/main/java/com/sludev/commons/vfs2/provider/azure/AzFileSystem.java
@@ -58,7 +58,7 @@ public class AzFileSystem
 
         log.info("Azure single upload block size : " + singleBlockSize + " Bytes");
 
-        Integer parallelUploadThread = null;
+        Integer parallelUploadThread = 2;
 
         String threadProperty = System.getProperty("azure.parallel.upload.thread");
         if (NumberUtils.isNumber(threadProperty)) {

--- a/vfs-azure/src/main/resources/META-INF/vfs-providers.xml
+++ b/vfs-azure/src/main/resources/META-INF/vfs-providers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<providers>
+    <provider class-name="com.sludev.commons.vfs2.provider.azure.AzFileProvider">
+        <scheme name="azsb"/>
+        <scheme name="azsf"/>
+    </provider>
+</providers>

--- a/vfs-azure/src/test/java/com/sludev/commons/vfs2/provider/azure/AzFileProviderTest.java
+++ b/vfs-azure/src/test/java/com/sludev/commons/vfs2/provider/azure/AzFileProviderTest.java
@@ -122,7 +122,7 @@ public class AzFileProviderTest
         }
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.addProvider("file", new DefaultLocalFileProvider());
         currMan.init(); 
         
@@ -132,7 +132,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "test01.tmp";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         FileObject currFile2 = currMan.resolveFile(
                 String.format("file://%s", temp.getAbsolutePath()));
@@ -153,7 +153,7 @@ public class AzFileProviderTest
         File temp = File.createTempFile("downloadFile01", ".tmp");
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.addProvider("file", new DefaultLocalFileProvider());
         currMan.init(); 
         
@@ -163,7 +163,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "test01.tmp";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         String destStr = String.format("file://%s", temp.getAbsolutePath());
@@ -184,7 +184,7 @@ public class AzFileProviderTest
         String currFileNameStr;
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.init(); 
         
         StaticUserAuthenticator auth = new StaticUserAuthenticator("", currAccountStr, currKey);
@@ -193,7 +193,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "test01.tmp";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         log.info( String.format("exist() file '%s'", currUriStr));
@@ -204,7 +204,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "non-existant-file-8632857264.tmp";
         currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currAccountStr, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currAccountStr, currContainerStr, currFileNameStr);
         currFile = currMan.resolveFile(currUriStr, opts);
         
         log.info( String.format("exist() file '%s'", currUriStr));
@@ -223,7 +223,7 @@ public class AzFileProviderTest
         String currFileNameStr;
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.init(); 
         
         StaticUserAuthenticator auth = new StaticUserAuthenticator("", currAccountStr, currKey);
@@ -232,7 +232,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "test01.tmp";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         log.info( String.format("exist() file '%s'", currUriStr));
@@ -258,7 +258,7 @@ public class AzFileProviderTest
         String currHost = testProperties.getProperty("azure.host");  // <account>.blob.core.windows.net
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.init(); 
         
         StaticUserAuthenticator auth = new StaticUserAuthenticator("", currAccountStr, currKey);
@@ -267,7 +267,7 @@ public class AzFileProviderTest
         
         String currFileNameStr = "uploadFile02";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         FileObject[] currObjs = currFile.getChildren();
@@ -292,7 +292,7 @@ public class AzFileProviderTest
         String currFileNameStr;
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.init(); 
         
         StaticUserAuthenticator auth = new StaticUserAuthenticator("", currAccountStr, currKey);
@@ -301,7 +301,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "file05";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         FileContent content = currFile.getContent();
@@ -322,7 +322,7 @@ public class AzFileProviderTest
         String currFileNameStr;
         
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.init(); 
         
         StaticUserAuthenticator auth = new StaticUserAuthenticator("", currAccountStr, currKey);
@@ -331,7 +331,7 @@ public class AzFileProviderTest
         
         currFileNameStr = "test01.tmp";
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, currHost, currContainerStr, currFileNameStr);
+                           AzConstants.AZBSSCHEME, currHost, currContainerStr, currFileNameStr);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         log.info( String.format("deleting '%s'", currUriStr));

--- a/vfs-azure/src/test/java/com/sludev/commons/vfs2/provider/azure/AzTestContentType.java
+++ b/vfs-azure/src/test/java/com/sludev/commons/vfs2/provider/azure/AzTestContentType.java
@@ -1,0 +1,52 @@
+package com.sludev.commons.vfs2.provider.azure;
+
+import org.apache.tika.Tika;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class AzTestContentType {
+
+    private static Tika tika;
+
+
+    @BeforeClass
+    public static void doSetUp() {
+
+        tika = new Tika();
+    }
+
+
+    @Test
+    public void testMP4() {
+
+        String output = tika.detect("abc.mp4");
+        assertEquals("video/mp4", output);
+    }
+
+
+    @Test
+    public void testMOV() {
+
+        String output = tika.detect("abc.mov");
+        assertEquals("video/quicktime", output);
+    }
+
+
+    @Test
+    public void testTXT() {
+
+        String output = tika.detect("abc.txt");
+        assertEquals("text/plain", output);
+    }
+
+
+    @Test
+    public void testWithoutExt() {
+
+        String output = tika.detect("abc");
+        assertEquals("application/octet-stream", output);
+    }
+}

--- a/vfs-azure/src/test/java/com/sludev/commons/vfs2/provider/azure/AzTestUtils.java
+++ b/vfs-azure/src/test/java/com/sludev/commons/vfs2/provider/azure/AzTestUtils.java
@@ -41,7 +41,7 @@ public class AzTestUtils
                                        Path localFile, Path remotePath) throws FileSystemException
     {
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.addProvider("file", new DefaultLocalFileProvider());
         currMan.init(); 
         
@@ -50,7 +50,7 @@ public class AzTestUtils
         DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator(opts, auth); 
         
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, accntHost, containerName, remotePath);
+                           AzConstants.AZBSSCHEME, accntHost, containerName, remotePath);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         FileObject currFile2 = currMan.resolveFile(
                 String.format("file://%s", localFile));
@@ -65,7 +65,7 @@ public class AzTestUtils
                                        Path remotePath) throws FileSystemException
     {
         DefaultFileSystemManager currMan = new DefaultFileSystemManager();
-        currMan.addProvider(AzConstants.AZSBSCHEME, new AzFileProvider());
+        currMan.addProvider(AzConstants.AZBSSCHEME, new AzFileProvider());
         currMan.init(); 
         
         StaticUserAuthenticator auth = new StaticUserAuthenticator("", accntName, accntKey);
@@ -73,7 +73,7 @@ public class AzTestUtils
         DefaultFileSystemConfigBuilder.getInstance().setUserAuthenticator(opts, auth); 
         
         String currUriStr = String.format("%s://%s/%s/%s", 
-                           AzConstants.AZSBSCHEME, accntHost, containerName, remotePath);
+                           AzConstants.AZBSSCHEME, accntHost, containerName, remotePath);
         FileObject currFile = currMan.resolveFile(currUriStr, opts);
         
         Boolean delRes = currFile.delete();


### PR DESCRIPTION
Updated to azbs to align with what it stand for "Azure Blob Storage"

Important change is Override getChildren() method for AzFileObject to throw FileNotFolderException for File Blob Object. This one is real problem when we make getChildren() call on File and it returns empty, it's difficult to identify whether it's real file object or an empty folder in VFS.

Support file operation for secured storage account

Fixed the issue of detecting file type while copying file
